### PR TITLE
Feature/fastdevrun

### DIFF
--- a/ppdet/engine/trainer.py
+++ b/ppdet/engine/trainer.py
@@ -77,7 +77,7 @@ class Trainer(object):
         self.max_iters = self.cfg.get('iters', None)
 
         # set fast dev run
-        self.fast_dev_run = self.cfg.get('fast_dev_run', (False, False))
+        self.fast_dev_run = self.cfg.get('use_fastrun', (False, False))
         if isinstance(self.fast_dev_run, (list, tuple)):
             pass
         elif isinstance(self.fast_dev_run, dict):

--- a/ppdet/engine/trainer.py
+++ b/ppdet/engine/trainer.py
@@ -73,6 +73,34 @@ class Trainer(object):
         self.custom_white_list = self.cfg.get('custom_white_list', None)
         self.custom_black_list = self.cfg.get('custom_black_list', None)
 
+        # Iter per epoch( if none, use len(loader) )
+        self.max_iters = self.cfg.get('iters', None)
+
+        # set fast dev run
+        self.fast_dev_run = self.cfg.get('fast_dev_run', (False, False))
+        if isinstance(self.fast_dev_run, (list, tuple)):
+            pass
+        elif isinstance(self.fast_dev_run, dict):
+            self.fast_dev_run = (self.fast_dev_run.get('epochs', 7),
+                                 self.fast_dev_run.get('iters', 7))
+        elif isinstance(self.fast_dev_run, bool):
+            self.fast_dev_run = (7, 7) if self.fast_dev_run else (False, False)
+        elif isinstance(self.fast_dev_run, int):
+            self.fast_dev_run = (self.fast_dev_run, self.fast_dev_run)
+        else:
+            logger.error(
+                "fast_dev_run should be bool, int, list, tuple or dict")
+            raise TypeError(
+                "fast_dev_run should be bool, int, list, tuple or dict, but got {}".
+                format(type(self.fast_dev_run)))
+
+        if self.fast_dev_run != (False, False):
+            self.cfg.snapshot_epoch = 2
+            logger.info("fast_dev_run is enabled, and will run {} epochs and {} iters".
+                        format(*self.fast_dev_run))
+            self.cfg.epoch = self.fast_dev_run[0] if self.fast_dev_run[0] else self.max_epoch
+            self.max_iters = self.fast_dev_run[1] if self.fast_dev_run[1] else self.max_iters
+
         # build data loader
         capital_mode = self.mode.capitalize()
         if cfg.architecture in MOT_ARCH and self.mode in ['eval', 'test']:
@@ -548,6 +576,16 @@ class Trainer(object):
                 if self.use_ema:
                     self.ema.update()
                 iter_tic = time.time()
+       
+                if self.max_iters and step_id >= self.max_iters:
+                    logger.info(
+                        'Reach max_iters, stop training now, total iters: {}'.
+                        format(step_id))
+                    if self.fast_dev_run[1]:
+                        logger.info(
+                            'fast_dev_run is enabled, stop epoch now'
+                        )
+                    break
 
             if self.cfg.get('unstructured_prune'):
                 self.pruner.update_params()
@@ -596,6 +634,10 @@ class Trainer(object):
                 # reset original weight
                 self.model.set_dict(weight)
                 self.status.pop('weight')
+
+                        
+            if self.fast_dev_run[0]:
+                logger.info('fast_dev_run is enabled, stop training now')
 
         self._compose_callback.on_train_end(self.status)
 

--- a/tools/train.py
+++ b/tools/train.py
@@ -109,6 +109,11 @@ def parse_args():
         action='store_true',
         default=False,
         help="Enable dy2st to train.")
+    parser.add_argument(
+        "--use_fastrun",
+        type=bool,
+        default=False,
+        help="Runs 7 batches of train, val and test to find bugs (ie: a simple unit test).")
 
     args = parser.parse_args()
     return args


### PR DESCRIPTION
The fast dev run mode is a development tool that allows developers to quickly and efficiently test and debug their code. This mode allows developers to run their config in less epochs ande iters.
``` yaml
use_fastrun: True

use_fastrun:
  epochs: 7
  iters: 128
```
 This helps developers to identify and fix issues more quickly and easily, allowing them to develop and deploy their code faster and with fewer errors. 
The fast dev run mode is a valuable tool for any developer looking to streamline their workflow and improve the efficiency of their development process.